### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ readme = "README.md"
 repository = "https://github.com/Dylan-DPC/crypt3"
 
 [dependencies]
-md5 = "0.6"
-ring = "0.13"
+md5 = "0.7"
+ring = "0.16"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ const FORMATS: &[(&str, &str); 6] = &[
 /// password and a salt. The first 3 bytes of the salt decide which algorithm is picked and
 /// should be in the $id$ form (e.g. $1$ for MD5).
 
-pub fn crypt<'a>(password: &'a [u8], salt: &'a [u8]) -> Result<Vec<u8>, Box<Error>> {
+pub fn crypt<'a>(password: &'a [u8], salt: &'a [u8]) -> Result<Vec<u8>, Box<dyn Error>> {
     if let Some(magic) = format_from_magic(salt) {
         delegate(*magic, password, salt)
     } else {
@@ -66,8 +66,8 @@ fn delegate<'a>(
     algorithm: (&'a str, &'a str),
     password: &'a [u8],
     salt: &'a [u8],
-) -> Result<Vec<u8>, Box<Error>> {
-    let digest: Result<Encrypted, Box<Error>> = match algorithm.0 {
+) -> Result<Vec<u8>, Box<dyn Error>> {
+    let digest: Result<Encrypted, Box<dyn Error>> = match algorithm.0 {
         "md5" => Ok(Encrypted::Md5(compute(password))),
         "sha256" => Ok(Encrypted::Sha256(digest(&SHA256, password))),
         "sha512" => Ok(Encrypted::Sha512(digest(&SHA512, password))),


### PR DESCRIPTION
Hi!
A small PR updating dependencies (and fixing warnings in the same move).
I need to use this crate for interoperability with linux shadow files (getpwnam, getspnam), but I already have a dependency on ring in my workspace, causing an error such as

```
error: failed to select a version for `ring`.
    ... required by package `myapp v0.1.0`

versions that meet the requirements `^0.16.0` are: 0.16.17, 0.16.19, 0.16.18, 0.16.16, 0.16.15, 0.16.14, 0.16.13, 0.16.12, 0.16.11, 0.16.10, 0.16.9, 0.16.7, 0.16.6, 0.16.5, 0.16.4, 0.16.3, 0.16.2, 0.16.1, 0.16.0

the package `ring` links to the native library `ring-asm`, but it conflicts with a previous package which links to `ring-asm` as well:
package `ring v0.13.5`
    ... which is depended on by `crypt3 v0.1.0`
    ... which is depended on by `myotherapp v0.1.0`

failed to select a version for `ring` which could resolve this conflict
```
Using an updated version of `crypt3` solves this issue.